### PR TITLE
Fixed Swagger Documentation not Rendering

### DIFF
--- a/src/main/java/com/lambdaschool/microfund/config/Swagger2Config.java
+++ b/src/main/java/com/lambdaschool/microfund/config/Swagger2Config.java
@@ -32,7 +32,7 @@ public class Swagger2Config
         return new Docket(DocumentationType.SWAGGER_2)
             .select()
             .apis(RequestHandlerSelectors
-                .basePackage("com.lambdaschool.foundation"))
+                .basePackage("com.lambdaschool.microfund"))
             .paths(PathSelectors.regex("/.*"))
             .build()
             .apiInfo(apiEndPointsInfo());
@@ -45,11 +45,8 @@ public class Swagger2Config
      */
     private ApiInfo apiEndPointsInfo()
     {
-        return new ApiInfoBuilder().title("Java Spring BE Foundation")
-            .description("Java Spring Backend Foundation and Scaffolding")
-            .contact(new Contact("John Mitchell",
-                "http://www.lambdaschool.com",
-                "john@lambdaschool.com"))
+        return new ApiInfoBuilder().title("Java Spring BE for Microfund")
+            .description("Java Spring Backend")
             .license("MIT")
             .licenseUrl("https://github.com/LambdaSchool/java-springfoundation/blob/master/LICENSE")
             .version("1.0.0")


### PR DESCRIPTION
When I refactored the name of the project, swagger wasn't automatically refactored.

I updated the package it was looking for, so now the documentation will auto-generate again. While there, I also updated the contact information, description, etc

- [x] Bug fix (non-breaking change which fixes an issue)