### PR TITLE
Added organization push/patch/post endpoints

### DIFF
--- a/src/main/java/com/lambdaschool/microfund/controllers/OrganizationController.java
+++ b/src/main/java/com/lambdaschool/microfund/controllers/OrganizationController.java
@@ -1,15 +1,19 @@
 package com.lambdaschool.microfund.controllers;
 
 import com.lambdaschool.microfund.models.Organization;
+import com.lambdaschool.microfund.models.User;
 import com.lambdaschool.microfund.services.OrganizationService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
+import javax.validation.Valid;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.List;
 
 @RestController
@@ -31,5 +35,58 @@ public class OrganizationController
     {
         Organization o = orgService.findOrgById(orgId);
         return new ResponseEntity<>(o, HttpStatus.OK);
+    }
+
+
+    @PostMapping(value = "/",
+        consumes = "application/json")
+    public ResponseEntity<?> addNewOrg(
+        @Valid
+        @RequestBody
+            Organization neworg) throws
+        URISyntaxException
+    {
+        neworg.setOrgid(0);
+        neworg = orgService.save(neworg);
+
+        // set the location header for the newly created resource
+        HttpHeaders responseHeaders = new HttpHeaders();
+        URI newOrgURI = ServletUriComponentsBuilder.fromCurrentRequest()
+            .path("/{orgid}")
+            .buildAndExpand(neworg.getOrgid())
+            .toUri();
+        responseHeaders.setLocation(newOrgURI);
+
+        return new ResponseEntity<>(null,
+            responseHeaders,
+            HttpStatus.CREATED);
+    }
+
+    @PutMapping(value = "/{orgid}",
+        consumes = "application/json")
+    public ResponseEntity<?> updateFullOrg(
+        @Valid
+        @RequestBody
+            Organization updateOrg,
+        @PathVariable
+            long orgid)
+    {
+        updateOrg.setOrgid(orgid);
+        orgService.save(updateOrg);
+
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @PatchMapping(value = "/{orgid}",
+        consumes = "application/json")
+    public ResponseEntity<?> updateOrg(
+        @RequestBody
+            Organization updateOrg,
+        @PathVariable
+            long id)
+    {
+        orgService.update(updateOrg,
+            id);
+        return new ResponseEntity<>(HttpStatus.OK);
     }
 }

--- a/src/main/java/com/lambdaschool/microfund/controllers/OrganizationController.java
+++ b/src/main/java/com/lambdaschool/microfund/controllers/OrganizationController.java
@@ -83,10 +83,10 @@ public class OrganizationController
         @RequestBody
             Organization updateOrg,
         @PathVariable
-            long id)
+            long orgid)
     {
         orgService.update(updateOrg,
-            id);
+            orgid);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 }

--- a/src/main/java/com/lambdaschool/microfund/services/OrganizationServiceImpl.java
+++ b/src/main/java/com/lambdaschool/microfund/services/OrganizationServiceImpl.java
@@ -102,6 +102,13 @@ public class OrganizationServiceImpl
                 .add(new OrganizationMembers(orgM.getUser(), newOrg));
         }
 
+        newOrg.getQuestions().clear();
+        for (Question question : org.getQuestions())
+        {
+            newOrg.getQuestions()
+                .add(new Question(newOrg, question.getQuestion()));
+        }
+
         return orgrepos.save(newOrg);
     }
 
@@ -119,6 +126,11 @@ public class OrganizationServiceImpl
                 .toLowerCase());
         }
 
+        if (org.getDescription() != null)
+        {
+            currentOrg.setDescription(org.getDescription());
+        }
+
         if (org.getMembers()
             .size() > 0)
         {
@@ -133,6 +145,18 @@ public class OrganizationServiceImpl
                     .add(new OrganizationMembers(addUser, currentOrg));
             }
         }
+
+        if (org.getQuestions()
+            .size() > 0)
+        {
+            currentOrg.getQuestions().clear();
+            for (Question question : org.getQuestions())
+            {
+                currentOrg.getQuestions()
+                    .add(new Question(currentOrg, question.getQuestion()));
+            }
+        }
+
 
         return orgrepos.save(currentOrg);
     }


### PR DESCRIPTION
Adding new organizations and updating them is now possible via endpoints. Questions can also be added via these endpoints, which I assume will be the main way that is done.

Most of the modifications are in the controller, adding the endpoints. However I realized while testing that org questions and description had been neglected in the service save/update methods, so those were added in as well.

I did not add any delete endpoints for organizations. I'm assuming that is not something we want people to be able to do easily or at all. If anyone thinks otherwise however, I'd be happy to add it, just let me know.

- [X] New feature (non-breaking change which adds functionality)